### PR TITLE
Enable https for hosts-file.net

### DIFF
--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -41,7 +41,7 @@
       },
       {
         "title": "hpHosts’s Ad and tracking servers",
-        "location": "http://hosts-file.net/ad_servers.txt",
+        "location": "https://hosts-file.net/ad_servers.txt",
         "state": 2
       },
       {


### PR DESCRIPTION
hosts-file.net allows https for downloading the hosts file.

I would go so far and only enable the hosts sources which allow download by https to protect against MitM attackers in open wifi networks. Modifying the hosts file is a great target for an attacker ;)

Greetings from the original AdAway developer. I no longer use rooted phones on a daily basis, thus DNS66 is a great alternative to AdAway.
