### PR TITLE
Add ability to selectively whitelist apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
             android:label="@string/activity_edit"
             android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme" />
+        <activity
+            android:name=".WhitelistActivity"
+            android:theme="@style/AppTheme.Dialog" />
 
         <service
             android:name=".vpn.AdVpnService"

--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -80,11 +80,5 @@
         "state": 0
       }
     ]
-  },
-  "whitelist": {
-    "items": [
-      "org.jak_linux.dns66",
-      "com.android.vending"
-    ]
   }
 }

--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -80,5 +80,11 @@
         "state": 0
       }
     ]
+  },
+  "whitelist": {
+    "items": [
+      "org.jak_linux.dns66",
+      "com.android.vending"
+    ]
   }
 }

--- a/app/src/main/java/org/jak_linux/dns66/Configuration.java
+++ b/app/src/main/java/org/jak_linux/dns66/Configuration.java
@@ -208,6 +208,12 @@ public class Configuration {
             }
         }
         reader.endObject();
+
+        if (whitelist == null) {
+            whitelist = new Whitelist();
+            whitelist.items.add("org.jak_linux.dns66");
+            whitelist.items.add("com.android.vending");
+        }
     }
 
     public static class Item {

--- a/app/src/main/java/org/jak_linux/dns66/Configuration.java
+++ b/app/src/main/java/org/jak_linux/dns66/Configuration.java
@@ -24,6 +24,30 @@ public class Configuration {
     public boolean autoStart;
     public Hosts hosts;
     public DnsServers dnsServers;
+    public Whitelist whitelist;
+
+    private static Whitelist readWhitelist(JsonReader reader) throws IOException {
+        Whitelist whitelist = new Whitelist();
+        reader.beginObject();
+
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "items":
+                    reader.beginArray();
+                    while (reader.hasNext())
+                        whitelist.items.add(reader.nextString());
+
+                    reader.endArray();
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+
+        return whitelist;
+    }
 
     private static Hosts readHosts(JsonReader reader) throws IOException {
         Hosts hosts = new Hosts();
@@ -101,6 +125,17 @@ public class Configuration {
         return item;
     }
 
+    private static void writeWhitelist(JsonWriter writer, Whitelist w) throws IOException {
+        writer.beginObject();
+        writer.name("items");
+        writer.beginArray();
+        for (String string : w.items) {
+            writer.value(string);
+        }
+        writer.endArray();
+        writer.endObject();
+    }
+
     private static void writeHosts(JsonWriter writer, Hosts h) throws IOException {
         writer.beginObject();
         writer.name("enabled").value(h.enabled);
@@ -141,6 +176,8 @@ public class Configuration {
         writeHosts(writer, hosts);
         writer.name("dnsServers");
         writeDnsServers(writer, dnsServers);
+        writer.name("whitelist");
+        writeWhitelist(writer, whitelist);
         writer.endObject();
     }
 
@@ -161,6 +198,9 @@ public class Configuration {
                     break;
                 case "dnsServers":
                     dnsServers = readDnsServers(reader);
+                    break;
+                case "whitelist":
+                    whitelist = readWhitelist(reader);
                     break;
                 default:
                     reader.skipValue();
@@ -187,5 +227,9 @@ public class Configuration {
     public static class DnsServers {
         public boolean enabled;
         public List<Item> items = new ArrayList<>();
+    }
+
+    public static class Whitelist {
+        public List<String> items = new ArrayList<>();
     }
 }

--- a/app/src/main/java/org/jak_linux/dns66/MainActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/MainActivity.java
@@ -142,6 +142,9 @@ public class MainActivity extends AppCompatActivity {
 
                 startActivityForResult(exportIntent, REQUEST_FILE_STORE);
                 break;
+            case R.id.action_whitelist:
+                startActivity(new Intent(this, WhitelistActivity.class));
+                break;
             case R.id.action_about:
                 Intent infoIntent = new Intent(this, InfoActivity.class);
                 startActivity(infoIntent);

--- a/app/src/main/java/org/jak_linux/dns66/WhitelistActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/WhitelistActivity.java
@@ -1,0 +1,157 @@
+/* Copyright (C) 2016 Julian Andres Klode <jak@jak-linux.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package org.jak_linux.dns66;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Activity showing a list of apps that are whitelisted by the VPN.
+ *
+ * @author Braden Farmer
+ */
+public class WhitelistActivity extends AppCompatActivity {
+
+    private AppListGenerator appListGenerator;
+    private ProgressBar progressBar;
+    private ListView appList;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_whitelist);
+        setFinishOnTouchOutside(false);
+        setTitle(getString(R.string.action_whitelist));
+
+        progressBar = (ProgressBar) findViewById(R.id.progress_bar);
+        appList = (ListView) findViewById(R.id.list);
+
+        appListGenerator = new AppListGenerator();
+        appListGenerator.execute();
+    }
+
+    @Override
+    public void finish() {
+        if(appListGenerator != null && appListGenerator.getStatus() == AsyncTask.Status.RUNNING)
+            appListGenerator.cancel(true);
+
+        FileHelper.writeSettings(this, MainActivity.config);
+
+        super.finish();
+    }
+
+    private class AppListAdapter extends ArrayAdapter<ListEntry> {
+        AppListAdapter(Context context, int layout, List<ListEntry> list) {
+            super(context, layout, list);
+        }
+
+        @Override
+        public View getView(int position, View convertView, final ViewGroup parent) {
+            // Check if an existing view is being reused, otherwise inflate the view
+            if(convertView == null)
+                convertView = LayoutInflater.from(getContext()).inflate(R.layout.whitelist_row, parent, false);
+
+            final ListEntry entry = getItem(position);
+
+            TextView textView = (TextView) convertView.findViewById(R.id.name);
+            textView.setText(entry.getLabel());
+
+            final CheckBox checkBox = (CheckBox) convertView.findViewById(R.id.checkbox);
+            checkBox.setChecked(MainActivity.config.whitelist.items.contains(entry.getPackageName()));
+
+            LinearLayout layout = (LinearLayout) convertView.findViewById(R.id.entry);
+            layout.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    if(MainActivity.config.whitelist.items.contains(entry.getPackageName())) {
+                        MainActivity.config.whitelist.items.remove(entry.getPackageName());
+                        checkBox.setChecked(false);
+                    } else {
+                        MainActivity.config.whitelist.items.add(entry.getPackageName());
+                        checkBox.setChecked(true);
+                    }
+                }
+            });
+
+            return convertView;
+        }
+    }
+
+    private final class AppListGenerator extends AsyncTask<Void, Void, AppListAdapter> {
+        @Override
+        protected AppListAdapter doInBackground(Void... params) {
+            final PackageManager pm = getPackageManager();
+
+            Intent intent = new Intent(Intent.ACTION_MAIN);
+            intent.addCategory(Intent.CATEGORY_LAUNCHER);
+            List<ResolveInfo> info = pm.queryIntentActivities(intent, 0);
+
+            Collections.sort(info, new Comparator<ResolveInfo>() {
+                @Override
+                public int compare(ResolveInfo ai1, ResolveInfo ai2) {
+                    return ai1.activityInfo.loadLabel(pm).toString().compareTo(ai2.activityInfo.loadLabel(pm).toString());
+                }
+            });
+
+            final List<ListEntry> entries = new ArrayList<>();
+            for(ResolveInfo appInfo : info) {
+                if(!appInfo.activityInfo.applicationInfo.packageName.equals(BuildConfig.APPLICATION_ID))
+                    entries.add(new ListEntry(
+                            appInfo.activityInfo.applicationInfo.packageName,
+                            appInfo.loadLabel(pm).toString()));
+            }
+
+            return new AppListAdapter(WhitelistActivity.this, R.layout.whitelist_row, entries);
+        }
+
+        @Override
+        protected void onPostExecute(AppListAdapter adapter) {
+            progressBar.setVisibility(View.GONE);
+            appList.setAdapter(adapter);
+            setFinishOnTouchOutside(true);
+        }
+    }
+
+    private class ListEntry {
+        private String packageName;
+        private String label;
+
+        private ListEntry(String packageName, String label) {
+            this.packageName = packageName;
+            this.label = label;
+        }
+
+        private String getPackageName() {
+            return packageName;
+        }
+
+        private String getLabel() {
+            return label;
+        }
+    }
+}

--- a/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnThread.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnThread.java
@@ -67,9 +67,6 @@ class AdVpnThread implements Runnable {
     /* Maximum number of responses we want to wait for */
     private static final int DNS_MAXIMUM_WAITING = 1024;
     private static final long DNS_TIMEOUT_SEC = 10;
-    // Apps using DownloadManager that are known to be broken on Nougat when a VPN is active, see
-    // issue #31 for further details.
-    private static final String[] NOUGAT_APP_WHITELIST = {"org.jak_linux.dns66", "com.android.vending"};
 
     private final VpnService vpnService;
     private final Notify notify;
@@ -528,7 +525,7 @@ class AdVpnThread implements Runnable {
 
         // Work around DownloadManager bug on Nougat - It cannot resolve DNS
         // names while a VPN service is active.
-        for (String app : NOUGAT_APP_WHITELIST) {
+        for (String app : config.whitelist.items) {
             try {
                 Log.d(TAG, "configure: Disallowing " + app + " from using the DNS VPN");
                 builder.addDisallowedApplication(app);

--- a/app/src/main/res/layout/activity_whitelist.xml
+++ b/app/src/main/res/layout/activity_whitelist.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             android:paddingTop="4dp"
+             android:paddingBottom="4dp" >
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="44dp"
+        android:layout_marginBottom="44dp"
+        android:layout_gravity="center" />
+
+    <ListView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/whitelist_row.xml
+++ b/app/src/main/res/layout/whitelist_row.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/entry"
+              android:layout_height="wrap_content"
+              android:layout_width="match_parent"
+              android:paddingLeft="8dp"
+              android:paddingRight="8dp"
+              android:paddingTop="4dp"
+              android:paddingBottom="4dp" >
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="false" />
+
+    <TextView
+        android:id="@+id/name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_gravity="center_vertical"
+        android:textSize="18sp"
+        android:maxLines="1"
+        android:ellipsize="end" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -29,6 +29,11 @@
         android:title="@string/action_export"
         app:showAsAction="never" />
     <item
+        android:id="@+id/action_whitelist"
+        android:orderInCategory="100"
+        android:title="@string/action_whitelist"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_about"
         android:icon="@drawable/ic_menu_info"
         android:orderInCategory="100"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="button_no">No</string>
     <string name="button_yes">Yes</string>
     <string name="website" translatable="false">https://github.com/julian-klode/dns66</string>
+    <string name="action_whitelist">Whitelisted apps</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -28,4 +28,10 @@
         <item name="welcomeButtonSkipText">@string/welcome_button_skip</item>
         <item name="welcomeButtonDoneText">@string/welcome_button_done</item>
     </style>
+
+    <style name="AppTheme.Dialog" parent="Theme.AppCompat.Light.Dialog">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
 </resources>


### PR DESCRIPTION
This adds an option in the overflow menu for the user to select individual apps to whitelist from the VPN, so that more apps can work around issue #31.

(One caveat: this will require the user to reset settings to default, otherwise, the VPN will not start successfully)