### PR TITLE
Quick settings tile for Android version 7.0+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.0"
     defaultConfig {
         applicationId "org.jak_linux.dns66"
         minSdkVersion 21
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 6
         versionName "0.2.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -27,10 +27,10 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:support-v4:24.2.1'
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:recyclerview-v7:25.1.0'
     compile 'com.aurelhubert:ahbottomnavigation:1.5.1'
     compile 'com.stephentuso:welcome:1.0.0'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,12 +40,24 @@
         <activity
             android:name=".WhitelistActivity"
             android:theme="@style/AppTheme.Dialog" />
+        <activity android:name=".tile.TileStartActivity"
+            android:theme="@style/AppTheme.Translucent"/>
 
         <service
             android:name=".vpn.AdVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".tile.VpnTileService"
+            android:icon="@drawable/ic_menu_start_white"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/org/jak_linux/dns66/MainActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/MainActivity.java
@@ -170,7 +170,7 @@ public class MainActivity extends AppCompatActivity {
 
             if (file != null && item.state != 2) {
                 DownloadManager.Request request = new DownloadManager.Request(Uri.parse(item.location));
-                Log.d("MainActivity", String.format("refresh: Downkoading %s to %s", item.location, file.getAbsolutePath()));
+                Log.d("MainActivity", String.format("refresh: Downloading %s to %s", item.location, file.getAbsolutePath()));
                 file.delete();
                 request.setDestinationUri(Uri.fromFile(file));
                 request.setTitle(item.title);

--- a/app/src/main/java/org/jak_linux/dns66/main/StartFragment.java
+++ b/app/src/main/java/org/jak_linux/dns66/main/StartFragment.java
@@ -57,11 +57,7 @@ public class StartFragment extends Fragment {
             @Override
             public boolean onLongClick(View v) {
                 if (AdVpnService.vpnStatus != AdVpnService.VPN_STATUS_STOPPED) {
-                    Log.i(TAG, "Attempting to disconnect");
-
-                    Intent intent = new Intent(getActivity(), AdVpnService.class);
-                    intent.putExtra("COMMAND", org.jak_linux.dns66.vpn.Command.STOP.ordinal());
-                    getActivity().startService(intent);
+                    stopService();
                 } else {
                     checkHostsFilesAndStartService();
                 }
@@ -81,8 +77,8 @@ public class StartFragment extends Fragment {
         return rootView;
     }
 
-    private void checkHostsFilesAndStartService() {
-        if (!areHostsFilesExistant()) {
+    protected void checkHostsFilesAndStartService() {
+        if (!areHostsFilesExistent()) {
             new AlertDialog.Builder(getActivity())
                     .setIcon(R.drawable.ic_warning)
                     .setTitle(R.string.missing_hosts_files_title)
@@ -90,7 +86,7 @@ public class StartFragment extends Fragment {
                     .setNegativeButton(R.string.button_no, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-                            /* Do nothing */
+                            onCancelStart();
                         }
                     })
                     .setPositiveButton(R.string.button_yes, new DialogInterface.OnClickListener() {
@@ -105,8 +101,16 @@ public class StartFragment extends Fragment {
         startService();
     }
 
+	/**
+     * Called when the start of the service was canceled after some host files were missing
+     */
+    protected void onCancelStart() {
+         /* Do nothing */
+    }
+
     private void startService() {
         Log.i(TAG, "Attempting to connect");
+
         Intent intent = VpnService.prepare(getContext());
         if (intent != null) {
             startActivityForResult(intent, REQUEST_START_VPN);
@@ -115,12 +119,20 @@ public class StartFragment extends Fragment {
         }
     }
 
+    protected void stopService() {
+        Log.i(TAG, "Attempting to disconnect");
+
+        Intent intent = new Intent(getActivity(), AdVpnService.class);
+        intent.putExtra("COMMAND", org.jak_linux.dns66.vpn.Command.STOP.ordinal());
+        getActivity().startService(intent);
+    }
+
     /**
      * Check if all configured hosts files exist.
      *
      * @return true if all host files exist or no host files were configured.
      */
-    private boolean areHostsFilesExistant() {
+    private boolean areHostsFilesExistent() {
         if (!MainActivity.config.hosts.enabled)
             return true;
         for (Configuration.Item item : MainActivity.config.hosts.items) {

--- a/app/src/main/java/org/jak_linux/dns66/tile/TileStartActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/tile/TileStartActivity.java
@@ -1,0 +1,24 @@
+package org.jak_linux.dns66.tile;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import org.jak_linux.dns66.FileHelper;
+import org.jak_linux.dns66.MainActivity;
+import org.jak_linux.dns66.R;
+
+public class TileStartActivity extends AppCompatActivity {
+
+	@Override
+	protected void onCreate(@Nullable Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		// If the config was not initialized, do it here
+		if (MainActivity.config == null) {
+			MainActivity.config = FileHelper.loadCurrentSettings(this);
+		}
+
+		setContentView(R.layout.activity_tile);
+	}
+}

--- a/app/src/main/java/org/jak_linux/dns66/tile/TileStartFragment.java
+++ b/app/src/main/java/org/jak_linux/dns66/tile/TileStartFragment.java
@@ -1,0 +1,63 @@
+package org.jak_linux.dns66.tile;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.jak_linux.dns66.R;
+import org.jak_linux.dns66.main.StartFragment;
+import org.jak_linux.dns66.vpn.AdVpnService;
+
+import static android.app.Activity.RESULT_CANCELED;
+import static android.app.Activity.RESULT_OK;
+
+/**
+ * Handle the launch of the AdVpnService from the TileActivity
+ */
+public class TileStartFragment extends StartFragment {
+
+	private static final String TAG = "TileStartFragment";
+
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		return inflater.inflate(R.layout.fragment_tile, container, false);
+	}
+
+	@Override
+	public void onAttach(Context context) {
+		super.onAttach(context);
+
+		// Immediately start or stop the service
+		if (AdVpnService.vpnStatus != AdVpnService.VPN_STATUS_STOPPED) {
+			Log.d(TAG, "Stopping service");
+
+			stopService();
+			getActivity().finish();
+		} else {
+			Log.d(TAG, "Starting service");
+
+			checkHostsFilesAndStartService();
+		}
+	}
+
+	@Override
+	protected void onCancelStart() {
+		// Dismiss the activity if the user cancels the start
+		getActivity().finish();
+	}
+
+	@Override
+	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+
+		// If the service was correctly launched, dismiss this activity
+		if (requestCode == REQUEST_START_VPN &&
+				(resultCode == RESULT_OK || resultCode == RESULT_CANCELED)) {
+			getActivity().finish();
+		}
+	}
+}

--- a/app/src/main/java/org/jak_linux/dns66/tile/VpnTileService.java
+++ b/app/src/main/java/org/jak_linux/dns66/tile/VpnTileService.java
@@ -1,0 +1,57 @@
+package org.jak_linux.dns66.tile;
+
+import android.annotation.TargetApi;
+import android.content.Intent;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+
+import org.jak_linux.dns66.R;
+import org.jak_linux.dns66.vpn.AdVpnService;
+
+/**
+ * TileService enabling a Tile to start or stop the service
+ */
+@TargetApi(Build.VERSION_CODES.N)
+public class VpnTileService extends TileService {
+
+	@Override
+	public void onTileAdded() {
+		super.onTileAdded();
+	}
+
+	@Override
+	public void onTileRemoved() {
+		super.onTileRemoved();
+	}
+
+	@Override
+	public void onStartListening() {
+		super.onStartListening();
+
+		Tile tile = getQsTile();
+		tile.setIcon(Icon.createWithResource(this, R.drawable.ic_menu_start_white));
+		tile.setLabel(getString(R.string.app_name));
+		tile.setContentDescription(getString(R.string.start_tab));
+		tile.setState(
+				AdVpnService.vpnStatus == AdVpnService.VPN_STATUS_STOPPED ?
+						Tile.STATE_INACTIVE :
+						Tile.STATE_ACTIVE);
+		tile.updateTile();
+	}
+
+	@Override
+	public void onStopListening() {
+		super.onStopListening();
+	}
+
+	@Override
+	public void onClick() {
+		Tile tile = getQsTile();
+		tile.setState(tile.getState() == Tile.STATE_INACTIVE ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
+		tile.updateTile();
+
+		startActivity(new Intent(this, TileStartActivity.class));
+	}
+}

--- a/app/src/main/res/layout/activity_tile.xml
+++ b/app/src/main/res/layout/activity_tile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+          android:layout_height="match_parent"
+          android:layout_width="match_parent"
+          android:name="org.jak_linux.dns66.tile.TileStartFragment">
+</fragment>

--- a/app/src/main/res/layout/fragment_tile.xml
+++ b/app/src/main/res/layout/fragment_tile.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Space xmlns:android="http://schemas.android.com/apk/res/android"
+       android:background="@android:color/transparent"
+          android:layout_height="wrap_content"
+          android:layout_width="wrap_content">
+
+</Space>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -6,4 +6,13 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
+
+    <style name="AppTheme.Translucent" parent="AppTheme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
 </resources>


### PR DESCRIPTION
Adds a tile in the quick settings with a basic icon and text for now.
The tile acts as a toggle starting / stopping the AdVpnService.
Update of build versions and dependencies to be able to use the tile.

Fixes #26