### PR TITLE
Extensive matching

### DIFF
--- a/app/src/main/java/org/jak_linux/dns66/Configuration.java
+++ b/app/src/main/java/org/jak_linux/dns66/Configuration.java
@@ -34,6 +34,7 @@ public class Configuration {
     public int version = 1;
     public boolean autoStart;
     public Hosts hosts = new Hosts();
+    public ExtendedFiltering extendedFiltering = new ExtendedFiltering();
     public DnsServers dnsServers = new DnsServers();
     public Whitelist whitelist = new Whitelist();
     public boolean showNotification = true;
@@ -76,6 +77,10 @@ public class Configuration {
         public boolean enabled;
         public boolean automaticRefresh = false;
         public List<Item> items = new ArrayList<>();
+    }
+
+    public static class ExtendedFiltering {
+        public boolean enabled;
     }
 
     public static class DnsServers {

--- a/app/src/main/java/org/jak_linux/dns66/db/RuleDatabase.java
+++ b/app/src/main/java/org/jak_linux/dns66/db/RuleDatabase.java
@@ -283,7 +283,7 @@ public class RuleDatabase {
             // containing all the entries of the domain blacklist.
 
             for (int i = 0; i < 50; i++) {
-                // strip up to 10 leading parts (so that there is an upper bound for performance reasons)
+                // strip up to 50 leading parts (so that there is an upper bound for performance reasons)
                 String[] split_host = host.split("\\.", 2);
                 if (split_host.length <= 1) {
                     // there's nothing to chop off left

--- a/app/src/main/java/org/jak_linux/dns66/db/RuleDatabase.java
+++ b/app/src/main/java/org/jak_linux/dns66/db/RuleDatabase.java
@@ -77,10 +77,13 @@ public class RuleDatabase {
 
         // Reject AdBlock Plus filters like these
         // www.google.com#@##videoads
+        // youtube.com###companion
         // because otherwise, the filter exception (#@##videoads) would be treated as a comment
         // and then www.google.com would be treated as a domain (presumably to block).
         // This is as fast as using indexOf - https://stackoverflow.com/a/10714409.
         if (line.contains("#@#"))
+            return null;
+        if (line.contains("###"))
             return null;
 
         int endOfLine = line.indexOf('#');
@@ -279,7 +282,7 @@ public class RuleDatabase {
             // of a string in a hashset 1-10 times than to build and evaluate a huge regexp
             // containing all the entries of the domain blacklist.
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 50; i++) {
                 // strip up to 10 leading parts (so that there is an upper bound for performance reasons)
                 String[] split_host = host.split("\\.", 2);
                 if (split_host.length <= 1) {
@@ -294,6 +297,8 @@ public class RuleDatabase {
                     return true;
                 }
             }
+            // A domain name with 50 components is a pathological case, let's block it
+            return true;
         }
         return false;
     }

--- a/app/src/main/java/org/jak_linux/dns66/db/RuleDatabase.java
+++ b/app/src/main/java/org/jak_linux/dns66/db/RuleDatabase.java
@@ -296,9 +296,11 @@ public class RuleDatabase {
                 if (blockedHosts.get().contains(host)) {
                     return true;
                 }
+                if (i == 49) {
+                    // A domain name with 50 components is a pathological case, let's block it
+                    return true;
+                }
             }
-            // A domain name with 50 components is a pathological case, let's block it
-            return true;
         }
         return false;
     }

--- a/app/src/main/java/org/jak_linux/dns66/main/HostsFragment.java
+++ b/app/src/main/java/org/jak_linux/dns66/main/HostsFragment.java
@@ -62,6 +62,16 @@ public class HostsFragment extends Fragment implements FloatingActionButtonFragm
             }
         });
 
+        Switch extendedFilteringEnabled = (Switch) rootView.findViewById(R.id.extended_filtering_enabled);
+        extendedFilteringEnabled.setChecked(MainActivity.config.extendedFiltering.enabled);
+        extendedFilteringEnabled.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                MainActivity.config.extendedFiltering.enabled = isChecked;
+                FileHelper.writeSettings(getContext(), MainActivity.config);
+            }
+        });
+
         Switch automaticRefresh = (Switch) rootView.findViewById(R.id.automatic_refresh);
         automaticRefresh.setChecked(MainActivity.config.hosts.automaticRefresh);
         automaticRefresh.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {

--- a/app/src/main/res/layout/extra_bar_hosts.xml
+++ b/app/src/main/res/layout/extra_bar_hosts.xml
@@ -106,6 +106,22 @@
         </LinearLayout>
 
         <Switch
+            android:id="@+id/extended_filtering_enabled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="8dp"
+            android:paddingTop="8dp"
+            android:saveEnabled="false"
+            android:text="@string/extended_filtering"/>
+
+        <TextView
+            android:id="@+id/extended_filtering_enabled_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="8dp"
+            android:text="@string/extended_filtering_description"/>
+
+        <Switch
             android:id="@+id/automatic_refresh"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,8 @@
     <string name="expand_bar_closed">Closed</string>
     <string name="action_stop">Stop</string>
     <string name="action_start">Start</string>
+    <string name="extended_filtering">Extensive filtering</string>
+    <string name="extended_filtering_description">Assume wildcard in front of all domains in lists, merge subdomains below third-level domains (fourth for .co.uk and similar), strip www. from domains in lists.</string>
     <string name="automatic_refresh">Refresh daily</string>
     <string name="automatic_refresh_description">Daily updates occur when charging, idle, and on an unmetered network.</string>
     <string name="watchdog">Watch connection</string>

--- a/app/src/test/java/org/jak_linux/dns66/db/RuleDatabaseTest.java
+++ b/app/src/test/java/org/jak_linux/dns66/db/RuleDatabaseTest.java
@@ -150,14 +150,33 @@ public class RuleDatabaseTest {
         assertTrue(db.isEmpty());
         assertFalse(db.isBlocked("example.com"));
 
+        assertTrue(db.loadReader(item, new StringReader("whitelisted.www.foo.com")));
+        assertTrue(db.loadReader(item, new StringReader("whitelisted.foo.com")));
+        assertTrue(db.loadReader(item, new StringReader("whitelisted.bad.foo.com")));
+
+
         // Check multiple lines
         item.state = Configuration.Item.STATE_DENY;
         assertFalse(db.isBlocked("example.com"));
         assertFalse(db.isBlocked("foo.com"));
-        assertTrue(db.loadReader(item, new StringReader("example.com\n127.0.0.1 foo.com")));
+        assertTrue(db.loadReader(item, new StringReader("example.com\n127.0.0.1 foo.com\nbad.foo.com")));
         assertFalse(db.isEmpty());
         assertFalse(db.isBlocked("example.com"));  // it has been explicitly whitelisted above
         assertTrue(db.isBlocked("foo.com"));
+        assertFalse(db.isBlocked("www.foo.com"));
+
+        db.config = new Configuration();
+        db.config.extendedFiltering.enabled = true;
+
+        assertTrue(db.isBlocked("www.foo.com"));
+        assertTrue(db.isBlocked("bar.foo.com"));
+        assertTrue(db.isBlocked("bad.foo.com"));
+        assertFalse(db.isBlocked("whitelisted.www.foo.com"));
+        assertFalse(db.isBlocked("whitelisted.foo.com"));
+        assertFalse(db.isBlocked("whitelisted.bad.foo.com"));
+        assertFalse(db.isBlocked("foobar.whitelisted.bad.foo.com"));
+        assertTrue(db.isBlocked("foobar.baz.foo.com"));
+        assertTrue(db.isBlocked("baz.bad.foo.com"));
 
         // Interrupted test
         Thread.currentThread().interrupt();


### PR DESCRIPTION
Hi @julian-klode, I like your dns66 quite a lot and had an idea that it might be possible to make the domain-matching algorithm more extensive.

Some lists (such as Badd Boyz Hosts) contain only second-level domains but it's desirable to block any access to them - even to sub-domains.

This is a rough quick idea sketch not intended for merge, described in the commit and described in the code. Works fine for me so far. My aim is to get your opinion.

What do you think about it? Is it worthwile? Something I apparently didn't consider? Would there be a better way?

Some of my ideas for next actions:
* Make this a user-configurable & importable/exportable option (to choose either the classic hosts-like exact domain matching or this extensive matching, to choose the number of parts in the generated second subdomain in addHost(), and coming up with an option name and description comprehensible for a normal user).
* If source list contains www.example.com, also add example.com.
* Implement support for ublock/adblock domain name syntax (that'll require a lot of thought probably because URLs can't be supported, only domain names, and style filters have to be ignored).
* Add tests.

Upfront, I will probably have very slow progress on this, maybe one commit in 6 months or sth like that.

Thanks