### PR TITLE
Notification Rework

### DIFF
--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -51,7 +51,7 @@
       },
       {
         "title": "Dan Pollock's hosts file",
-        "location": "http://someonewhocares.org/hosts/hosts",
+        "location": "https://someonewhocares.org/hosts/hosts",
         "state": 0
       },
       {

--- a/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnService.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnService.java
@@ -184,7 +184,7 @@ public class AdVpnService extends VpnService implements Handler.Callback {
                 .setSmallIcon(R.drawable.ic_state_deny) // TODO: Notification icon
                 .setPriority(Notification.PRIORITY_LOW)
                 .setAutoCancel(true)
-                .setContentTitle(getString(R.string.notification_paused_title))
+                .setContentTitle("Paused")
                 .setContentText(getString(R.string.notification_paused_text))
                 .setContentIntent(PendingIntent.getService(this, REQUEST_CODE_START, getStartIntent(this), PendingIntent.FLAG_ONE_SHOT))
                 .build());
@@ -193,7 +193,9 @@ public class AdVpnService extends VpnService implements Handler.Callback {
     private void updateVpnStatus(int status) {
         vpnStatus = status;
         int notificationTextId = vpnStatusToTextId(status);
-        notificationBuilder.setContentText(getString(notificationTextId));
+        notificationBuilder
+                .setContentTitle(getString(notificationTextId))
+                .setShowWhen(false);
 
         if (FileHelper.loadCurrentSettings(getApplicationContext()).showNotification)
             startForeground(NOTIFICATION_ID_STATE, notificationBuilder.build());


### PR DESCRIPTION
Changed text to title for activity notifications and changed paused title to more accurately display VPN status on low priority notifications. Also removed ShowWhen for activity notifications due to the nature of these notifications. Paused still shows when it was prompted for user review.
New low priority notifications:
![image](https://user-images.githubusercontent.com/35777938/40937896-18d43f64-680e-11e8-891e-6a03ab1808e8.png)
![image](https://user-images.githubusercontent.com/35777938/40937911-275ba586-680e-11e8-97c0-5c0330e70284.png)