### PR TITLE
Changing someonewhocares host from http to https

### DIFF
--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -51,7 +51,7 @@
       },
       {
         "title": "Dan Pollock's hosts file",
-        "location": "http://someonewhocares.org/hosts/hosts",
+        "location": "https://someonewhocares.org/hosts/hosts",
         "state": 0
       },
       {


### PR DESCRIPTION
The document has moved to https but DNS66 is not following the redirect.

```
$ curl http://someonewhocares.org/hosts/hosts
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://someonewhocares.org/hosts/hosts">here</a>.</p>
</body></html>
```