### PR TITLE
Fixed issue with Dan Pollock's hosts file

### DIFF
--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -51,7 +51,7 @@
       },
       {
         "title": "Dan Pollock's hosts file",
-        "location": "http://someonewhocares.org/hosts/hosts",
+        "location": "https://someonewhocares.org/hosts/hosts",
         "state": 0
       },
       {


### PR DESCRIPTION
Dan Pollock's hosts file should be https or else it is not working.

Fixes:
https://github.com/julian-klode/dns66/issues/293
https://github.com/julian-klode/dns66/issues/301