### PR TITLE
fix cast catch toString() exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - tools # repository-11
     - tools # upgrade tools
     - platform-tools
-    - build-tools-28.0.3
+    - build-tools-29.0.2
     - android-29
     - extra-android-support
     - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
-    buildToolsVersion = '28.0.3'
+    buildToolsVersion = '29.0.2'
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.pcap4j:pcap4j-packetfactory-static:1.8.2'
     implementation 'dnsjava:dnsjava:2.1.9'
 
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/app/src/main/java/org/jak_linux/dns66/vpn/DnsPacketProxy.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/DnsPacketProxy.java
@@ -185,6 +185,10 @@ public class DnsPacketProxy {
             return;
         }
         String dnsQueryName = dnsMsg.getQuestion().getName().toString(true);
+        if (!dnsQueryName.contains(".")) {
+            Log.d(TAG, "handleDnsRequest: Invalid DNS query: " + dnsMsg);
+        }
+        Log.d(TAG, "handleDnsRequest: IpPacket: " + parsedPacket);
         if (dnsQueryName.contains(".") && !ruleDatabase.isBlocked(dnsQueryName.toLowerCase(Locale.ENGLISH))) {
             Log.i(TAG, "handleDnsRequest: DNS Name " + dnsQueryName + " Allowed, sending to " + destAddr);
             DatagramPacket outPacket = new DatagramPacket(dnsRawData, 0, dnsRawData.length, destAddr, parsedUdp.getHeader().getDstPort().valueAsInt());

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip


### PR DESCRIPTION
I got a new Pixel phone and rooted it with Magisk to benefit from DNS adblocking and iptables firewall (AdAway and AFWall+), but MagiskHide wasn't working with some banking apps, including GPay, so I decided to un-root. Flashed latest factory image and everything works, but no adblock.

Installed DNS66 and it kept crashing, so I started debugging. The initial exception was:
```
java.lang.IllegalArgumentException: arr is empty.
E AdVpnThread: 	at org.pcap4j.util.ByteArrays.validateBounds(ByteArrays.java:953)
E AdVpnThread: 	at org.pcap4j.util.ByteArrays.toHexString(ByteArrays.java:771)
E AdVpnThread: 	at org.pcap4j.util.ByteArrays.toHexString(ByteArrays.java:760)
E AdVpnThread: 	at org.pcap4j.packet.UnknownTcpOption.toString(UnknownTcpOption.java:147)
E AdVpnThread: 	at java.lang.String.valueOf(String.java:2924)
E AdVpnThread: 	at java.lang.StringBuilder.append(StringBuilder.java:132)
E AdVpnThread: 	at org.pcap4j.packet.TcpPacket$TcpHeader.buildString(TcpPacket.java:945)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket$AbstractHeader$4.buildValue(AbstractPacket.java:416)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket$AbstractHeader$4.buildValue(AbstractPacket.java:413)
E AdVpnThread: 	at org.pcap4j.util.LazyValue.getValue(LazyValue.java:41)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket$AbstractHeader.toString(AbstractPacket.java:530)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket.buildString(AbstractPacket.java:236)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket$4.buildValue(AbstractPacket.java:68)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket$4.buildValue(AbstractPacket.java:65)
E AdVpnThread: 	at org.pcap4j.util.LazyValue.getValue(LazyValue.java:41)
E AdVpnThread: 	at org.pcap4j.packet.AbstractPacket.toString(AbstractPacket.java:252)
E AdVpnThread: 	at java.lang.String.valueOf(String.java:2924)
E AdVpnThread: 	at java.lang.StringBuilder.append(StringBuilder.java:132)
E AdVpnThread: 	at org.jak_linux.dns66.vpn.DnsPacketProxy.handleDnsRequest(DnsPacketProxy.java:152)
```
`parsedPacket.getPayload()` throws this exception for non-UDP/invalid packages. Fixed it replacing the `if` with a `try/catch` and now the app works 😄 

Then I noticed some weird DNS queries in the DNS66's logs, so I added two more debug logs to help with the inspection:
```
I/DnsPacketProxy: handleDnsRequest: Invalid DNS query: ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 23823
    ;; flags: rd ; qd: 1 an: 0 au: 0 ad: 0 
    ;; QUESTIONS:
    ;;    zbflznern., type = A, class = IN
    
    ;; ANSWERS:
    
    ;; AUTHORITY RECORDS:
    
    ;; ADDITIONAL RECORDS:
    
    ;; Message size: 27 bytes
I/DnsPacketProxy: handleDnsRequest: IpPacket: [IPv4 Header (20 bytes)]
      Version: 4 (IPv4)
      IHL: 5 (20 [bytes])
      TOS: [precedence: 0 (Routine)] [tos: 0 (Default)] [mbz: 0]
      Total length: 55 [bytes]
      Identification: 63362
      Flags: (Reserved, Don't Fragment, More Fragment) = (false, true, false)
      Fragment offset: 0 (0 [bytes])
      TTL: 64
      Protocol: 17 (UDP)
      Header checksum: 0xbf2f
      Source address: /192.0.2.1
      Destination address: /192.0.2.2
    [UDP Header (8 bytes)]
      Source port: 23703 (unknown)
      Destination port: 53 (Domain Name Server)
      Length: 35 [bytes]
      Checksum: 0x0599
    [DNS Header (27 bytes)]
      ID: 0x5d0f
      QR: query
      OPCODE: 0 (Query)
      Authoritative Answer: false
      Truncated: false
      Recursion Desired: true
      Recursion Available: false
      Reserved Bit: 0
      Authentic Data: false
      Checking Disabled: false
      RCODE: 0 (No Error)
      QDCOUNT: 1
      ANCOUNT: 0
      NSCOUNT: 0
      ARCOUNT: 0
      Question:
        QNAME: zbflznern
        QTYPE: 1 (A (Host address))
        QCLASS: 1 (Internet (IN))
I/DnsPacketProxy: handleDnsRequest: DNS Name zbflznern Blocked!
```

Inspecting `top's` output, I noticed something else
```
 1159 shell        20   0 134M 4.8M 2.0M S  0.6   0.1  \
 0:04.72 adbd --root_seclabel=u:r:su:s0
```

_This is all running on *non-rooted* stock Android 10, latest build (qp1a.191005.007)._