### PR TITLE
Improve notifications

### DIFF
--- a/app/src/main/java/org/jak_linux/dns66/NotificationChannels.java
+++ b/app/src/main/java/org/jak_linux/dns66/NotificationChannels.java
@@ -25,8 +25,9 @@ public class NotificationChannels {
 
     public static void onCreate(Context context) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || notificationManager == null) {
             return;
+        }
 
         notificationManager.createNotificationChannelGroup(new NotificationChannelGroup(GROUP_SERVICE, context.getString(R.string.notifications_group_service)));
         notificationManager.createNotificationChannelGroup(new NotificationChannelGroup(GROUP_UPDATE, context.getString(R.string.notifications_group_updates)));

--- a/app/src/main/java/org/jak_linux/dns66/db/RuleDatabaseUpdateTask.java
+++ b/app/src/main/java/org/jak_linux/dns66/db/RuleDatabaseUpdateTask.java
@@ -17,6 +17,8 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
 import android.util.Log;
 
 import org.jak_linux.dns66.Configuration;
@@ -63,12 +65,11 @@ public class RuleDatabaseUpdateTask extends AsyncTask<Void, Void, Void> {
     private void setupNotificationBuilder() {
         notificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationBuilder = new NotificationCompat.Builder(context, NotificationChannels.UPDATE_STATUS);
-        notificationBuilder.setContentTitle(context.getString(R.string.updating_hostfiles))
-                .setContentText(context.getString(R.string.updating_hostfiles))
-                .setSmallIcon(R.drawable.ic_refresh);
-
-        notificationBuilder.setProgress(configuration.hosts.items.size(), 0, false);
+        notificationBuilder = new NotificationCompat.Builder(context, NotificationChannels.UPDATE_STATUS)
+                .setContentTitle(context.getString(R.string.updating_hostfiles))
+                .setSmallIcon(R.drawable.ic_refresh)
+                .setColor(ContextCompat.getColor(context, R.color.colorPrimaryDark))
+                .setProgress(configuration.hosts.items.size(), 0, false);
     }
 
     @Override
@@ -151,9 +152,9 @@ public class RuleDatabaseUpdateTask extends AsyncTask<Void, Void, Void> {
         }
 
         if (notificationBuilder != null) {
-            notificationBuilder.setProgress(pending.size() + done.size(), done.size(), false);
-            notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(builder.toString()));
-            notificationBuilder.setContentText(context.getString(R.string.updating_n_host_files, pending.size()));
+            notificationBuilder.setProgress(pending.size() + done.size(), done.size(), false)
+                    .setStyle(new NotificationCompat.BigTextStyle().bigText(builder.toString()))
+                    .setContentText(context.getString(R.string.updating_n_host_files, pending.size()));
             notificationManager.notify(UPDATE_NOTIFICATION_ID, notificationBuilder.build());
         }
     }

--- a/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnService.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnService.java
@@ -28,6 +28,7 @@ import android.os.Message;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.util.Log;
 
@@ -119,7 +120,8 @@ public class AdVpnService extends VpnService implements Handler.Callback {
 
         notificationBuilder.addAction(R.drawable.ic_pause_black_24dp, getString(R.string.notification_action_pause),
                 PendingIntent.getService(this, REQUEST_CODE_PAUSE, new Intent(this, AdVpnService.class)
-                                .putExtra("COMMAND", Command.PAUSE.ordinal()), 0));
+                                .putExtra("COMMAND", Command.PAUSE.ordinal()), 0))
+                .setColor(ContextCompat.getColor(this, R.color.colorPrimaryDark));
     }
 
     public static void checkStartVpnOnBoot(Context context) {
@@ -197,6 +199,7 @@ public class AdVpnService extends VpnService implements Handler.Callback {
         notificationManager.notify(NOTIFICATION_ID_STATE, new NotificationCompat.Builder(this, NotificationChannels.SERVICE_PAUSED)
                 .setSmallIcon(R.drawable.ic_state_deny) // TODO: Notification icon
                 .setPriority(Notification.PRIORITY_LOW)
+                .setColor(ContextCompat.getColor(this, R.color.colorPrimaryDark))
                 .setContentTitle(getString(R.string.notification_paused_title))
                 .setContentText(getString(R.string.notification_paused_text))
                 .setContentIntent(PendingIntent.getService(this, REQUEST_CODE_START, getResumeIntent(this), PendingIntent.FLAG_ONE_SHOT))
@@ -206,7 +209,7 @@ public class AdVpnService extends VpnService implements Handler.Callback {
     private void updateVpnStatus(int status) {
         vpnStatus = status;
         int notificationTextId = vpnStatusToTextId(status);
-        notificationBuilder.setContentText(getString(notificationTextId));
+        notificationBuilder.setContentTitle(getString(notificationTextId));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O || FileHelper.loadCurrentSettings(getApplicationContext()).showNotification)
             startForeground(NOTIFICATION_ID_STATE, notificationBuilder.build());


### PR DESCRIPTION
* Add color
* Don't use DNS 66 as notification title. The app name is already shown in notifications as default. When I minimize the running notification, it said "DNS 66 * DNS 66" before. Now it says "DNS 66 * Active"
* Chain calls to the same builder object