### PR TITLE
Allow users to view full and filtered logcat output

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -1,0 +1,26 @@
+name: Debug Build
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+    - name: Upload APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: debugApk
+        path: app/build/outputs/apk/debug/**.apk

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,10 +17,10 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher"
         android:banner="@drawable/banner"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
@@ -32,7 +32,7 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
 
@@ -42,10 +42,16 @@
             android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme" />
         <activity
+            android:name=".LogsActivity"
+            android:label="@string/action_logcat"
+            android:parentActivityName=".MainActivity"
+            android:theme="@style/AppTheme" />
+        <activity
             android:name=".ItemActivity"
             android:label="@string/activity_edit"
             android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme" />
+
         <service
             android:name=".vpn.AdVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE">
@@ -55,8 +61,9 @@
         </service>
         <service
             android:name=".db.RuleDatabaseUpdateJobService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="true"/>
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
         <receiver
             android:name=".vpn.BootComplete"
             android:enabled="true"

--- a/app/src/main/java/org/jak_linux/dns66/LogsActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/LogsActivity.java
@@ -37,10 +37,20 @@ public class LogsActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        if (item.getItemId() == R.id.action_send_logcat) {
-            sendLogcat();
+        switch (item.getItemId()) {
+            case R.id.action_send_logcat:
+                sendLogcat();
+                break;
+            case R.id.action_refresh_logcat:
+                refresh();
+                break;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void refresh() {
+        currentLogcat = "";
+        viewLogcat();
     }
 
     private void viewLogcat() {
@@ -54,7 +64,9 @@ public class LogsActivity extends AppCompatActivity {
 
             currentLogcat = logcat;
 
-            ((TextView) findViewById(R.id.logs_output)).setText(logcat);
+            TextView logsOutput = findViewById(R.id.logs_output);
+            logsOutput.setText(logcat);
+            logsOutput.setHorizontallyScrolling(true);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/org/jak_linux/dns66/LogsActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/LogsActivity.java
@@ -2,6 +2,7 @@ package org.jak_linux.dns66;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
@@ -11,14 +12,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.jak_linux.dns66.vpn.DnsPacketProxy;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 
 public class LogsActivity extends AppCompatActivity {
 
-    String currentLogcat = null;
+    private final List<String> logcatOutput = new ArrayList<>(100);
+    private boolean showDnsRequestsOnly = true;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -26,12 +32,15 @@ public class LogsActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_logs);
 
+        ((TextView) findViewById(R.id.logs_output)).setHorizontallyScrolling(true);
+
         viewLogcat();
     }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.logcat, menu);
+        menu.findItem(R.id.option_only_show_dns_requests).setChecked(showDnsRequestsOnly);
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -42,51 +51,58 @@ public class LogsActivity extends AppCompatActivity {
                 sendLogcat();
                 break;
             case R.id.action_refresh_logcat:
-                refresh();
+                viewLogcat();
+                break;
+            case R.id.option_only_show_dns_requests:
+                toggleDnsRequestsFilter(item);
                 break;
         }
         return super.onOptionsItemSelected(item);
     }
 
-    private void refresh() {
-        currentLogcat = "";
-        viewLogcat();
+    private void toggleDnsRequestsFilter(MenuItem item) {
+        showDnsRequestsOnly = !showDnsRequestsOnly;
+        item.setChecked(showDnsRequestsOnly);
     }
 
     private void viewLogcat() {
         try {
-            String logcat = getLogcatOutput();
+            updateLogcatOutput();
 
-            if (logcat == null || logcat.trim().isEmpty()) {
+            if (logcatOutput.isEmpty()) {
                 Toast.makeText(this, R.string.logcat_empty, Toast.LENGTH_SHORT).show();
                 return;
             }
 
-            currentLogcat = logcat;
+            List<String> filteredLogs = logcatOutput;
+            if (showDnsRequestsOnly) {
+                filteredLogs = new ArrayList<>(20);
+                for (String line : logcatOutput) {
+                    if (line.contains(DnsPacketProxy.DNS_REQUESTS_FILTER_MESSAGE)) {
+                        filteredLogs.add(line);
+                    }
+                }
+            }
 
-            TextView logsOutput = findViewById(R.id.logs_output);
-            logsOutput.setText(logcat);
-            logsOutput.setHorizontallyScrolling(true);
-
+            String logsString = TextUtils.join("\n", filteredLogs);
+            ((TextView) findViewById(R.id.logs_output)).setText(logsString);
         } catch (Exception e) {
             e.printStackTrace();
             Toast.makeText(this, "Not supported: " + e, Toast.LENGTH_LONG).show();
         }
     }
 
-    private String getLogcatOutput() throws IOException {
+    private void updateLogcatOutput() throws IOException {
+        logcatOutput.clear();
         Process process = null;
         try {
             process = Runtime.getRuntime().exec("logcat -d");
             InputStream is = process.getInputStream();
             BufferedReader bis = new BufferedReader(new InputStreamReader(is));
-            StringBuilder logcat = new StringBuilder();
             String line;
             while ((line = bis.readLine()) != null) {
-                logcat.append(line);
-                logcat.append('\n');
+                logcatOutput.add(line);
             }
-            return logcat.toString();
         } finally {
             if (process != null) {
                 process.destroy();
@@ -95,16 +111,18 @@ public class LogsActivity extends AppCompatActivity {
     }
 
     private void sendLogcat() {
-        if (currentLogcat == null || currentLogcat.trim().isEmpty()) {
+        if (logcatOutput.isEmpty()) {
             Toast.makeText(this, R.string.logcat_empty, Toast.LENGTH_SHORT).show();
             return;
         }
+
+        String logsString = TextUtils.join("\n", logcatOutput);
 
         Intent eMailIntent = new Intent(Intent.ACTION_SEND);
         eMailIntent.setType("text/plain");
         eMailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{"jak@jak-linux.org"});
         eMailIntent.putExtra(Intent.EXTRA_SUBJECT, "DNS66 Logcat");
-        eMailIntent.putExtra(Intent.EXTRA_TEXT, currentLogcat);
+        eMailIntent.putExtra(Intent.EXTRA_TEXT, logsString);
         eMailIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(eMailIntent);
     }

--- a/app/src/main/java/org/jak_linux/dns66/LogsActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/LogsActivity.java
@@ -1,0 +1,99 @@
+package org.jak_linux.dns66;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class LogsActivity extends AppCompatActivity {
+
+    String currentLogcat = null;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_logs);
+
+        viewLogcat();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.logcat, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == R.id.action_send_logcat) {
+            sendLogcat();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void viewLogcat() {
+        try {
+            String logcat = getLogcatOutput();
+
+            if (logcat == null || logcat.trim().isEmpty()) {
+                Toast.makeText(this, R.string.logcat_empty, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            currentLogcat = logcat;
+
+            ((TextView) findViewById(R.id.logs_output)).setText(logcat);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Toast.makeText(this, "Not supported: " + e, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private String getLogcatOutput() throws IOException {
+        Process process = null;
+        try {
+            process = Runtime.getRuntime().exec("logcat -d");
+            InputStream is = process.getInputStream();
+            BufferedReader bis = new BufferedReader(new InputStreamReader(is));
+            StringBuilder logcat = new StringBuilder();
+            String line;
+            while ((line = bis.readLine()) != null) {
+                logcat.append(line);
+                logcat.append('\n');
+            }
+            return logcat.toString();
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+    private void sendLogcat() {
+        if (currentLogcat == null || currentLogcat.trim().isEmpty()) {
+            Toast.makeText(this, R.string.logcat_empty, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        Intent eMailIntent = new Intent(Intent.ACTION_SEND);
+        eMailIntent.setType("text/plain");
+        eMailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{"jak@jak-linux.org"});
+        eMailIntent.putExtra(Intent.EXTRA_SUBJECT, "DNS66 Logcat");
+        eMailIntent.putExtra(Intent.EXTRA_TEXT, currentLogcat);
+        eMailIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(eMailIntent);
+    }
+}

--- a/app/src/main/java/org/jak_linux/dns66/MainActivity.java
+++ b/app/src/main/java/org/jak_linux/dns66/MainActivity.java
@@ -211,40 +211,12 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(infoIntent);
                 break;
             case R.id.action_logcat:
-                sendLogcat();
+                Intent logsIntent = new Intent(this, LogsActivity.class);
+                startActivity(logsIntent);
                 break;
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    private void sendLogcat() {
-        Process proc = null;
-        try {
-            proc = Runtime.getRuntime().exec("logcat -d");
-            InputStream is = proc.getInputStream();
-            BufferedReader bis = new BufferedReader(new InputStreamReader(is));
-            StringBuilder logcat = new StringBuilder();
-            String line;
-            while ((line = bis.readLine()) != null) {
-                logcat.append(line);
-                logcat.append('\n');
-            }
-
-            Intent eMailIntent = new Intent(Intent.ACTION_SEND);
-            eMailIntent.setType("text/plain");
-            eMailIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{"jak@jak-linux.org"});
-            eMailIntent.putExtra(Intent.EXTRA_SUBJECT, "DNS66 Logcat");
-            eMailIntent.putExtra(Intent.EXTRA_TEXT, logcat.toString());
-            eMailIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(eMailIntent);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Toast.makeText(this, "Not supported: " + e, Toast.LENGTH_LONG).show();
-        } finally {
-            if (proc != null)
-                proc.destroy();
-        }
     }
 
     @Override

--- a/app/src/main/java/org/jak_linux/dns66/vpn/DnsPacketProxy.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/DnsPacketProxy.java
@@ -46,6 +46,7 @@ import java.util.Locale;
  */
 public class DnsPacketProxy {
 
+    public static final String DNS_REQUESTS_FILTER_MESSAGE = "handleDnsRequest: DNS Name ";
     private static final String TAG = "DnsPacketProxy";
     // Choose a value that is smaller than the time needed to unblock a host.
     private static final int NEGATIVE_CACHE_TTL_SECONDS = 5;
@@ -201,11 +202,11 @@ public class DnsPacketProxy {
         }
         String dnsQueryName = dnsMsg.getQuestion().getName().toString(true);
         if (!ruleDatabase.isBlocked(dnsQueryName.toLowerCase(Locale.ENGLISH))) {
-            Log.i(TAG, "handleDnsRequest: DNS Name " + dnsQueryName + " Allowed, sending to " + destAddr);
+            Log.i(TAG, DNS_REQUESTS_FILTER_MESSAGE + dnsQueryName + " Allowed, sending to " + destAddr);
             DatagramPacket outPacket = new DatagramPacket(dnsRawData, 0, dnsRawData.length, destAddr, parsedUdp.getHeader().getDstPort().valueAsInt());
             eventLoop.forwardPacket(outPacket, parsedPacket);
         } else {
-            Log.i(TAG, "handleDnsRequest: DNS Name " + dnsQueryName + " Blocked!");
+            Log.i(TAG, DNS_REQUESTS_FILTER_MESSAGE + dnsQueryName + " Blocked!");
             dnsMsg.getHeader().setFlag(Flags.QR);
             dnsMsg.getHeader().setRcode(Rcode.NOERROR);
             dnsMsg.addRecord(NEGATIVE_CACHE_SOA_RECORD, Section.AUTHORITY);

--- a/app/src/main/res/layout/activity_logs.xml
+++ b/app/src/main/res/layout/activity_logs.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="org.jak_linux.dns66.LogsActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/logs_output"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Logcat output" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_logs.xml
+++ b/app/src/main/res/layout/activity_logs.xml
@@ -4,23 +4,19 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context="org.jak_linux.dns66.LogsActivity">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/logs_output"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/logs_output"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:text="Logcat output" />
-
-    </LinearLayout>
+        android:scrollbars="horizontal|vertical"
+        android:scrollHorizontally="true"
+        android:textIsSelectable="true"
+        tools:text="@string/sample_logs" />
 
 </ScrollView>

--- a/app/src/main/res/menu/logcat.xml
+++ b/app/src/main/res/menu/logcat.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_send_logcat"
+        android:orderInCategory="100"
+        android:title="@string/action_send_logcat"
+        app:showAsAction="ifRoom|withText" />
+
+</menu>

--- a/app/src/main/res/menu/logcat.xml
+++ b/app/src/main/res/menu/logcat.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_refresh_logcat"
+        android:orderInCategory="100"
+        android:title="@string/action_refresh_logcat"
+        app:showAsAction="ifRoom|withText" />
+
+    <item
         android:id="@+id/action_send_logcat"
         android:orderInCategory="100"
         android:title="@string/action_send_logcat"

--- a/app/src/main/res/menu/logcat.xml
+++ b/app/src/main/res/menu/logcat.xml
@@ -4,9 +4,10 @@
 
     <item
         android:id="@+id/action_refresh_logcat"
+        android:icon="@drawable/ic_refresh"
         android:orderInCategory="100"
         android:title="@string/action_refresh_logcat"
-        app:showAsAction="ifRoom|withText" />
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_send_logcat"

--- a/app/src/main/res/menu/logcat.xml
+++ b/app/src/main/res/menu/logcat.xml
@@ -14,4 +14,11 @@
         android:title="@string/action_send_logcat"
         app:showAsAction="ifRoom|withText" />
 
+    <item
+        android:id="@+id/option_only_show_dns_requests"
+        android:checkable="true"
+        android:orderInCategory="100"
+        android:title="@string/option_only_show_dns_requests"
+        app:showAsAction="ifRoom|withText" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
     <string name="unstable_watchdog_message">Watching the connection may cause reconnects and the connection to get stuck</string>
     <string name="button_cancel">Cancel</string>
     <string name="button_continue">Continue</string>
+    <string name="logcat_empty">No logcat output found</string>
+    <string name="action_send_logcat">Send</string>
     <string-array name="allowlist_defaults">
         <item>No apps bypass by default</item>
         <item>All apps bypass by default</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="logcat_empty">No logcat output found</string>
     <string name="action_send_logcat">Send</string>
     <string name="action_refresh_logcat">Refresh</string>
+    <string name="option_only_show_dns_requests">Filter DNS requests</string>
     <string-array name="allowlist_defaults">
         <item>No apps bypass by default</item>
         <item>All apps bypass by default</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
         <item>Ignore</item>
     </string-array>
     <!-- Translate with something like <Language> Translation: Your Name -->
-    <string name="translator_credits"/>
+    <string name="translator_credits" />
     <string name="app_version_info">Version: %s</string>
     <string name="missing_hosts_files_message">Some of your configured (non-ignored) hosts files are missing.\n\nUse the ‘Refresh’ action to download hosts files.\n\nDo you still want to continue?</string>
     <string name="missing_hosts_files_title">Missing hosts file</string>
@@ -114,9 +114,29 @@
     <string name="button_continue">Continue</string>
     <string name="logcat_empty">No logcat output found</string>
     <string name="action_send_logcat">Send</string>
+    <string name="action_refresh_logcat">Refresh</string>
     <string-array name="allowlist_defaults">
         <item>No apps bypass by default</item>
         <item>All apps bypass by default</item>
         <item>System apps bypass by default</item>
     </string-array>
+    <string name="sample_logs">
+04-28 05:57:44.570   131   131 I chatty  : uid=1000(system) /system/bin/gatekeeperd expire 3 lines
+04-28 05:57:44.624   132   132 I chatty  : uid=0(root) /system/xbin/perfprofd expire 5 lines
+04-28 05:57:45.008   144   144 I chatty  : uid=0(root) /system/bin/dhcptool expire 61 lines
+04-28 05:57:46.338   270   270 I chatty  : uid=0(root) /system/bin/lmkd expire 4 lines
+04-28 05:57:47.547   274   274 D local_opengl: Starting local_opengl
+04-28 05:57:47.554   274   274 D local_opengl: Getting player version
+04-28 05:57:48.535   283   283 I chatty  : uid=0(root) /system/bin/debuggerd expire 3 lines
+04-28 05:57:48.577   287   287 I chatty  : uid=0(root) /system/bin/installd expire 9 lines
+04-28 05:57:48.911   279   279 E network_profile_handler: init_all_network_profile_state: wlan: eth1 phone:rmnet0
+04-28 05:57:48.911   279   279 I network_profile: Redis connect
+04-28 05:57:48.911   279   279 I network_profile: Redis PUB: network_profile status ready
+04-28 05:57:48.912   279   292 I network_profile: Redis read thread
+04-28 05:57:48.913   279   292 I network_profile: Redis read wait
+04-28 05:57:48.918   273   273 D vinput  : Starting Vinput Daemon
+04-28 05:57:48.918   273   273 D vinput  : send_status_async
+04-28 05:57:48.918   273   273 D vinput  : send_status
+04-28 05:57:48.919   273   273 W vinput  : Empty command, we ignore it
+    </string>
 </resources>


### PR DESCRIPTION
- Add github workflow to generate debug build on manual trigger
- Add new activity to view logcat output before sending it
- Add option to filter logcat to show DNS requests, both blocked and allowed
- Add send button to always send unfiltered logs
- Add refresh button to refresh logcat output

Resolves issue #471 